### PR TITLE
Add Highlights page with duration selector and video player

### DIFF
--- a/src/views/Highlights.vue
+++ b/src/views/Highlights.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="highlights">
+    <label for="duration">Highlight Duration</label>
+    <select id="duration" v-model="duration" @change="fetchHighlights">
+      <option v-for="d in durations" :key="d" :value="d">{{ d }}s</option>
+    </select>
+
+    <video v-if="videoUrl" controls :src="videoUrl" class="player"></video>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+const eventId = route.params.id
+
+const durations = [30, 60, 120]
+const duration = ref(durations[0])
+const videoUrl = ref('')
+
+async function fetchHighlights() {
+  try {
+    const res = await fetch(`/events/${eventId}/highlights?duration=${duration.value}`)
+    if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`)
+    const blob = await res.blob()
+    videoUrl.value = URL.createObjectURL(blob)
+  } catch (err) {
+    console.error(err)
+    videoUrl.value = ''
+  }
+}
+</script>
+
+<style scoped>
+.highlights {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.player {
+  width: 100%;
+  max-width: 640px;
+  background: #000;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add Highlights page that lets users select highlight duration and fetch compilation
- embed simple video player to stream generated highlight

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688de87ecdc4833398f38223a575a0a5